### PR TITLE
Added support for  TF 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+14.02.2020 (0.0.8)
+
+- Bumped version to 0.0.8
+- Added support for TF >= 2.0 and solved issue #14 
+- From this point forward `keras-unet` will import `tf.keras` instead of `Keras` when TF >= 2.0 is present.
+
 27.01.2020 (0.0.7)
 
 - Modified `custom_unet` to not use a bias when using BatchNorm

--- a/keras_unet/__init__.py
+++ b/keras_unet/__init__.py
@@ -1,10 +1,25 @@
 name = "keras_unet"
 
+__version__ = "0.0.7"
+# TODO add __all__
+
+# if tensorflow 2.x is present use tf.keras instead of Keras
+try:
+    from tensorflow import __version__ as TF_VERSION
+    from packaging import version
+    version.parse(TF_VERSION) >= version.parse("2.0.0")
+    TF = True
+except ImportError:
+    TF = False
+print('-----------------------------------------')
+if TF:
+    print('keras-unet init: TF version is >= 2.0.0 - using tf.keras instead of Keras')
+else:
+    print('keras-unet init: TF version is < 2.0.0 or not present - using Keras instead of tf.keras instead')
+print('-----------------------------------------')
+
 from . import models
 from . import losses
 from . import metrics
 from . import metrics_np
 from . import utils
-
-__version__ = "0.0.7"
-# TODO add __all__

--- a/keras_unet/losses.py
+++ b/keras_unet/losses.py
@@ -1,4 +1,8 @@
-from keras import backend as K
+from keras_unet import TF
+if TF:
+    from tensorflow.keras import backend as K
+else:
+    from keras import backend as K
 
 
 def jaccard_distance(y_true, y_pred, smooth=100):

--- a/keras_unet/metrics.py
+++ b/keras_unet/metrics.py
@@ -1,5 +1,10 @@
-from keras import backend as K
 import tensorflow as tf
+
+from keras_unet import TF
+if TF:
+    from tensorflow.keras import backend as K
+else:    
+    from keras import backend as K
 
 
 def iou(y_true, y_pred, smooth=1.):

--- a/keras_unet/models/custom_unet.py
+++ b/keras_unet/models/custom_unet.py
@@ -1,16 +1,32 @@
-from keras.models import Model
-from keras.layers import (
-    BatchNormalization,
-    Conv2D,
-    Conv2DTranspose,
-    MaxPooling2D,
-    Dropout,
-    SpatialDropout2D,
-    UpSampling2D,
-    Input,
-    concatenate,
-    Activation,
-)
+from keras_unet import TF
+if TF:
+    from tensorflow.keras.models import Model
+    from tensorflow.keras.layers import (
+        BatchNormalization,
+        Conv2D,
+        Conv2DTranspose,
+        MaxPooling2D,
+        Dropout,
+        SpatialDropout2D,
+        UpSampling2D,
+        Input,
+        concatenate,
+        Activation,
+    )
+else:
+    from keras.models import Model
+    from keras.layers import (
+        BatchNormalization,
+        Conv2D,
+        Conv2DTranspose,
+        MaxPooling2D,
+        Dropout,
+        SpatialDropout2D,
+        UpSampling2D,
+        Input,
+        concatenate,
+        Activation,
+    )
 
 
 def upsample_conv(filters, kernel_size, strides, padding):

--- a/keras_unet/models/satellite_unet.py
+++ b/keras_unet/models/satellite_unet.py
@@ -1,8 +1,22 @@
 # https://cdn-sv1.deepsense.ai/wp-content/uploads/2017/04/architecture_details.png
 # https://deepsense.ai/deep-learning-for-satellite-imagery-via-image-segmentation/
 
-from keras.models import Model
-from keras.layers import BatchNormalization, Conv2D, Conv2DTranspose, MaxPooling2D, UpSampling2D, Input, concatenate
+from keras_unet import TF
+if TF:
+    from tensorflow.keras.models import Model
+    from tensorflow.keras.layers import ( 
+        BatchNormalization, Conv2D, Conv2DTranspose,
+        MaxPooling2D, UpSampling2D, Input,
+        concatenate
+    )
+else:    
+    from keras.models import Model
+    from keras.layers import ( 
+        BatchNormalization, Conv2D, Conv2DTranspose,
+        MaxPooling2D, UpSampling2D, Input,
+        concatenate
+    )
+
 
 def bn_conv_relu(input, filters, bachnorm_momentum, **conv2d_args):
     x = BatchNormalization(momentum=bachnorm_momentum)(input)

--- a/keras_unet/models/vanilla_unet.py
+++ b/keras_unet/models/vanilla_unet.py
@@ -1,7 +1,21 @@
-from keras.models import Model
-from keras.backend import int_shape
-from keras.layers import BatchNormalization, Conv2D, Conv2DTranspose, MaxPooling2D, Dropout, Input, concatenate, Cropping2D
+from keras_unet import TF
+if TF:
+    from tensorflow.keras.models import Model
+    from tensorflow.keras.backend import int_shape
+    from tensorflow.keras.layers import (
+        BatchNormalization, Conv2D, Conv2DTranspose,
+        MaxPooling2D, Dropout, Input, concatenate, Cropping2D
+    )
+else:
+    from keras.models import Model
+    from keras.backend import int_shape
+    from keras.layers import (
+        BatchNormalization, Conv2D, Conv2DTranspose,
+        MaxPooling2D, Dropout, Input, concatenate, Cropping2D
+    )
+
 from .custom_unet import conv2d_block
+
 
 def vanilla_unet(
     input_shape,

--- a/keras_unet/utils.py
+++ b/keras_unet/utils.py
@@ -1,6 +1,12 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from keras.preprocessing.image import ImageDataGenerator
+
+from keras_unet import TF
+if TF:
+    from tensorflow.keras.preprocessing.image import ImageDataGenerator
+else:    
+    from keras.preprocessing.image import ImageDataGenerator
+
 
 # Runtime data augmentation
 def get_augmented(
@@ -265,7 +271,6 @@ def plot_patches(img_arr, org_img_size, stride=None, size=None):
             axes[i, j].set_axis_off()
             jj += 1
 
-########################
 
 def reconstruct_from_patches(img_arr, org_img_size, stride=None, size=None):
     # check parameters

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="keras-unet",
-    version="0.0.7",
+    version="0.0.8",
     description="Helper package with multiple U-Net implementations in Keras as well as useful utility tools helpful when working with image segmentation tasks",
     long_description=long_description,
     long_description_content_type="text/markdown",  # This is important!


### PR DESCRIPTION
Adds support for TF >= 2.0 and resolves #14  
From this point forward `keras-unet` will import `tf.keras` instead of `Keras` when TF >= 2.0 is present.
Bumps version to 0.0.8